### PR TITLE
data publishing over zmq implemented.

### DIFF
--- a/lanweatherd/makefile
+++ b/lanweatherd/makefile
@@ -1,9 +1,9 @@
 CC = g++
 LD = g++
 CCFLAGS = -Wall
-LDFLAGS = -lstdc++ -pthread -L ./target/debug/ -lnws_request
+LDFLAGS = -lstdc++ -pthread -L ./target/debug/ -lnws_request -lzmq
 EXE = lanweatherd
-OBJS = recent_data.o nws_loop.o main.o
+OBJS = recent_data.o nws_loop.o pub_loop.o rep_loop.o main.o
 RUSTLIB = target/debug/libnws_request.so
 
 RM = /bin/rm
@@ -22,3 +22,6 @@ $(RUSTLIB): src/lib.rs Cargo.toml
 
 clean:
 	$(RM) -rf *.o $(EXE) target/
+
+run-debug:
+	LD_LIBRARY_PATH=./target/debug ./lanweatherd

--- a/lanweatherd/src/main.cpp
+++ b/lanweatherd/src/main.cpp
@@ -11,6 +11,8 @@
 #include "main.h"
 #include "recent_data.h"
 #include "nws_loop.h"
+#include "pub_loop.h"
+#include "rep_loop.h"
 
 using namespace std;
 
@@ -71,10 +73,10 @@ int main(void) {
     thread thr_sensors_recv(nop);
     threads.push_back(move(thr_sensors_recv));
 
-    thread thr_bcast_all(nop);
+    thread thr_bcast_all(pub_loop, ref(cache));
     threads.push_back(move(thr_bcast_all));
 
-    thread thr_req_manager(nop);
+    thread thr_req_manager(rep_loop, ref(cache));
     threads.push_back(move(thr_req_manager));
 
     for (unsigned int i = 0; i < threads.size(); i++) {

--- a/lanweatherd/src/nws_loop.cpp
+++ b/lanweatherd/src/nws_loop.cpp
@@ -2,13 +2,13 @@
 
 #include "nws_loop.h"
 
-int SLEEP_INTERVAL = 60 * 15; // every 15 minutes
+int NWS_SLEEP_INTERVAL = 60 * 15; // every 15 minutes
 
 void nws_loop(recent_data& cache) {
     while (1) {
         char* response = nws_req();
         cache.update_nws_data(response);
 
-        sleep(SLEEP_INTERVAL);
+        sleep(NWS_SLEEP_INTERVAL);
     }
 }

--- a/lanweatherd/src/pub_loop.cpp
+++ b/lanweatherd/src/pub_loop.cpp
@@ -1,0 +1,27 @@
+#include <unistd.h>
+#include <cstdlib>
+#include <cstring>
+#include <zmq.h>
+
+#include "pub_loop.h"
+
+int PUB_PRE_SLEEP_INTERVAL = 60;
+int PUB_SLEEP_INTERVAL = 60 * 59;
+
+void pub_loop(recent_data& cache) {
+    void *context = zmq_ctx_new();
+    void *publisher = zmq_socket(context, ZMQ_PUB);
+    zmq_bind(publisher, "tcp://*:5670");
+
+    while (1) {
+        sleep(PUB_PRE_SLEEP_INTERVAL);
+        char* bundle = cache.get_data_bundle();
+        int msg_len = strlen(bundle);
+        zmq_send(publisher, bundle, msg_len, 0);
+        free(bundle);
+        sleep(PUB_SLEEP_INTERVAL);
+    }
+
+    zmq_close(publisher);
+    zmq_ctx_destroy(context);
+}

--- a/lanweatherd/src/pub_loop.h
+++ b/lanweatherd/src/pub_loop.h
@@ -1,0 +1,3 @@
+#include "recent_data.h"
+
+void pub_loop(recent_data& cache);

--- a/lanweatherd/src/rep_loop.cpp
+++ b/lanweatherd/src/rep_loop.cpp
@@ -1,0 +1,26 @@
+#include <unistd.h>
+#include <cstdlib>
+#include <cstring>
+#include <zmq.h>
+
+#include "rep_loop.h"
+
+void rep_loop(recent_data& cache) {
+    void *context = zmq_ctx_new();
+    void *responder = zmq_socket(context, ZMQ_REP);
+    zmq_bind(responder, "tcp://*:5680");
+
+    while (1) {
+        char buffer[256];
+        zmq_recv(responder, buffer, 255, 0);
+
+        char* bundle = cache.get_data_bundle();
+        int msg_len = strlen(bundle);
+
+        zmq_send(responder, bundle, msg_len, 0);
+        free(bundle);
+    }
+
+    zmq_close(responder);
+    zmq_ctx_destroy(context);
+}

--- a/lanweatherd/src/rep_loop.h
+++ b/lanweatherd/src/rep_loop.h
@@ -1,0 +1,3 @@
+#include "recent_data.h"
+
+void rep_loop(recent_data& cache);

--- a/lanweatherd/test_scripts/req_test.py
+++ b/lanweatherd/test_scripts/req_test.py
@@ -1,0 +1,15 @@
+import zmq
+
+ctx = zmq.Context()
+
+# pylint: disable=E1101
+socket = ctx.socket(zmq.REQ)
+
+socket.connect("tcp://localhost:5680")
+
+socket.send(b"launch the nukes")
+data = socket.recv(0, True, False)
+print(data)
+
+socket.close()
+ctx.destroy()

--- a/lanweatherd/test_scripts/sub_test.py
+++ b/lanweatherd/test_scripts/sub_test.py
@@ -1,0 +1,15 @@
+import zmq
+
+ctx = zmq.Context()
+
+# pylint: disable=E1101
+socket = ctx.socket(zmq.SUB)
+
+socket.connect("tcp://localhost:5670")
+socket.setsockopt(zmq.SUBSCRIBE, b"")
+
+data = socket.recv(0, True, False)
+print(data)
+
+socket.close()
+ctx.destroy()


### PR DESCRIPTION
closes #21 

data publishing over zmq implemented.
makefile updated for new files & run-debug target added for easy launching.
scripts for testing the endpoints.

probably should've done this in more than one commit. router got changed to rep because it will still handle things right with less manual work.