### PR TITLE
[#75] Exclude Archive from GitHub Language Stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+archive/** linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+# Exclude archive from GitHub language stats
 archive/** linguist-vendored


### PR DESCRIPTION
## Summary

This excludes our archive from the GitHub language stats to better reflect the makeup of the actively maintained parts of the project.

## Changes

- Add .gitattributes with exclusion for archive/

Closes #75