### PR TITLE
Set Minimum Dart Version to 3.10

### DIFF
--- a/flutterapp/pubspec.lock
+++ b/flutterapp/pubspec.lock
@@ -594,5 +594,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.10.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/flutterapp/pubspec.yaml
+++ b/flutterapp/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.19.3 <3.0.0'
+  sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary

We now use 3.10 as our minimum version of Dart.

## Changes

- Update version range in pubspec.yaml
- Update pubspec.lock