### PR TITLE
[#87] Change App Namespace

### DIFF
--- a/flutterapp/android/app/build.gradle.kts
+++ b/flutterapp/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.lanweather.flutterapp"
+    namespace = "com.lanweather.lanweatherapp"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -20,7 +20,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.lanweather.flutterapp"
+        applicationId = "com.lanweather.lanweatherapp"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/flutterapp/android/app/src/main/kotlin/com/lanweather/lanweatherapp/MainActivity.kt
+++ b/flutterapp/android/app/src/main/kotlin/com/lanweather/lanweatherapp/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.lanweather.flutterapp
+package com.lanweather.lanweatherapp
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/flutterapp/ios/Runner.xcodeproj/project.pbxproj
+++ b/flutterapp/ios/Runner.xcodeproj/project.pbxproj
@@ -492,7 +492,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.flutterapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.lanweatherapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -509,7 +509,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.flutterapp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.lanweatherapp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -527,7 +527,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.flutterapp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.lanweatherapp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -543,7 +543,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.flutterapp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.lanweatherapp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -675,7 +675,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.flutterapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.lanweatherapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -698,7 +698,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.flutterapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.lanweatherapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/flutterapp/ios/Runner/Info.plist
+++ b/flutterapp/ios/Runner/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>lanweather</string>
+	<string>lanweatherapp</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/flutterapp/linux/CMakeLists.txt
+++ b/flutterapp/linux/CMakeLists.txt
@@ -7,7 +7,7 @@ project(runner LANGUAGES CXX)
 set(BINARY_NAME "LANWeather")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.lanweather.flutterapp")
+set(APPLICATION_ID "com.lanweather.lanweatherapp")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/flutterapp/macos/Runner.xcodeproj/project.pbxproj
+++ b/flutterapp/macos/Runner.xcodeproj/project.pbxproj
@@ -479,7 +479,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.flutterapp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.lanweatherapp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/flutterapp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/flutterapp";
@@ -495,7 +495,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.flutterapp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.lanweatherapp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/flutterapp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/flutterapp";
@@ -511,7 +511,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.flutterapp.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.lanweatherapp.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/flutterapp.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/flutterapp";

--- a/flutterapp/macos/Runner/Configs/AppInfo.xcconfig
+++ b/flutterapp/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = LAN Weather
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.flutterapp
+PRODUCT_BUNDLE_IDENTIFIER = com.lanweather.lanweatherapp
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2026 com.lanweather. All rights reserved.


### PR DESCRIPTION
## Summary

This changes the app namespace to use something slightly more generic.

## Changes

- Changed `com.lanweather.flutterapp` to `com.lanweather.lanweatherapp`

Closes #87