### PR TITLE
[#66] Add Setting for Weather Server URL

### DIFF
--- a/flutterapp/lib/main.dart
+++ b/flutterapp/lib/main.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:lanweatherapp/screens/app_layout.dart';
+import 'package:lanweatherapp/services/preferences.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Preferences.init();
   runApp(MyApp());
 }
 

--- a/flutterapp/lib/screens/settings.dart
+++ b/flutterapp/lib/screens/settings.dart
@@ -1,31 +1,56 @@
 import 'package:flutter/material.dart';
+import 'package:lanweatherapp/services/preferences.dart';
 import 'package:lanweatherapp/strings.dart';
 
-class Settings extends StatelessWidget {
+class Settings extends StatefulWidget {
+  const Settings({super.key});
+
+  @override
+  _SettingsState createState() => _SettingsState();
+}
+
+class _SettingsState extends State<Settings> {
+  late TextEditingController textEditingController;
+
+  @override
+  void initState() {
+    super.initState();
+    textEditingController = TextEditingController(text: Preferences.getWeatherServerUrl());
+  }
+
+  @override
+  void dispose() {
+    textEditingController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     bool isMobile = MediaQuery.of(context).size.width < 600;
 
-    return isMobile
-        ? ListView(
-            padding: const EdgeInsets.symmetric(vertical: 40.0),
-            children: [
-              Container(
-                margin: const EdgeInsets.only(top: 18.0),
-                alignment: Alignment.center,
-                child: Text(Strings.settings, style: TextStyle(color: Colors.white, fontSize: 40)),
-              ),
-            ],
-          )
-        : ListView(
-            padding: const EdgeInsets.symmetric(vertical: 20.0),
-            children: [
-              Container(
-                margin: const EdgeInsets.only(top: 18.0),
-                alignment: Alignment.center,
-                child: Text(Strings.settings, style: TextStyle(color: Colors.white, fontSize: 40)),
-              ),
-            ],
-          );
+    return ListView(
+      padding: EdgeInsets.symmetric(vertical: isMobile ? 40.0 : 20.0, horizontal: 20.0),
+      children: [
+        Container(
+          margin: const EdgeInsets.only(top: 18.0, bottom: 25.0),
+          alignment: Alignment.center,
+          child: Text(Strings.settings, style: TextStyle(color: Colors.white, fontSize: 40)),
+        ),
+        TextField(
+          controller: textEditingController,
+          cursorColor: Colors.blue,
+          decoration: const InputDecoration(
+            label: Text("Weather server URL", style: TextStyle(color: Colors.white)),
+            enabledBorder: OutlineInputBorder(borderSide: BorderSide(color: Colors.white, width: 2.0)),
+            focusedBorder: OutlineInputBorder(borderSide: BorderSide(color: Colors.white, width: 3.0)),
+            hintStyle: TextStyle(color: Colors.white),
+          ),
+          onSubmitted: (String value) {
+            Preferences.setWeatherServerUrl(value);
+          },
+          style: TextStyle(color: Colors.white),
+        ),
+      ],
+    );
   }
 }

--- a/flutterapp/lib/services/preferences.dart
+++ b/flutterapp/lib/services/preferences.dart
@@ -1,0 +1,19 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class Preferences {
+  static late SharedPreferencesWithCache _preferences;
+
+  static Future<void> init() async {
+    _preferences = await SharedPreferencesWithCache.create(
+      cacheOptions: const SharedPreferencesWithCacheOptions(allowList: <String>{"weather_server_url"}),
+    );
+  }
+
+  static String getWeatherServerUrl() {
+    return _preferences.getString("weather_server_url") ?? "tcp://localhost:5680";
+  }
+
+  static void setWeatherServerUrl(String url) {
+    _preferences.setString("weather_server_url", url);
+  }
+}

--- a/flutterapp/lib/services/weather_api.dart
+++ b/flutterapp/lib/services/weather_api.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 
 import 'package:dartzmq/dartzmq.dart';
+import 'package:lanweatherapp/services/preferences.dart';
 
 Future<Map<String, dynamic>?> fetchAllWeatherData() async {
-  const String url = "tcp://localhost:5680";
   const String data = "launch the nukes";
+  String url = Preferences.getWeatherServerUrl();
 
   try {
     // TODO: Do we need to specify the number of threads?

--- a/flutterapp/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutterapp/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/flutterapp/macos/Podfile.lock
+++ b/flutterapp/macos/Podfile.lock
@@ -2,20 +2,27 @@ PODS:
   - dartzmq (1.0.0-dev.18):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - dartzmq (from `Flutter/ephemeral/.symlinks/plugins/dartzmq/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
 
 EXTERNAL SOURCES:
   dartzmq:
     :path: Flutter/ephemeral/.symlinks/plugins/dartzmq/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
 
 SPEC CHECKSUMS:
   dartzmq: 9f6e07c7f1ff35e7a2413933fe51772056d56a81
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
 
 PODFILE CHECKSUM: 89c84cf5c2351c1e554c6dea18d31a879fc3a19e
 

--- a/flutterapp/pubspec.lock
+++ b/flutterapp/pubspec.lock
@@ -228,6 +228,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -396,6 +401,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   pool:
     dependency: transitive
     description:
@@ -420,6 +465,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "8374d6200ab33ac99031a852eba4c8eb2170c4bf20778b3e2c9eccb45384fb41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.21"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -585,6 +686,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:
@@ -595,4 +704,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.35.0"

--- a/flutterapp/pubspec.yaml
+++ b/flutterapp/pubspec.yaml
@@ -43,6 +43,9 @@ dependencies:
   # Localization
   intl: ^0.20.2
 
+  # Preferences
+  shared_preferences: ^2.5.3
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary

You can now configure your weather server URL from the settings screen!

## Changes

- Add base infrastructure for storing and changing preferences
- Add setting for weather server URL

## Screenshots

### iOS

<img width="195" height="422" alt="IMG_7396" src="https://github.com/user-attachments/assets/b8c31765-9332-4caa-8651-eb9c8494e763" />

<img width="195" height="422" alt="IMG_7395" src="https://github.com/user-attachments/assets/6247f372-cb60-4aad-b493-33d0fcf99d49" />

### macOS

<img width="330" height="288.4" alt="Screenshot 2026-03-24 at 9 34 40 PM" src="https://github.com/user-attachments/assets/9e3d160a-cffe-4df6-8a5e-1f80d1f68cfc" />

<img width="330" height="288.4" alt="Screenshot 2026-03-24 at 9 34 35 PM" src="https://github.com/user-attachments/assets/9d32c3a8-4ddd-44ad-8b3b-85b4817cce74" />

Closes #66